### PR TITLE
[feature/OS-731] Analysis : when the code is updated in analysisitems tab, it is not modified in the treeview when saving

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Data/PropertyPathNode.cs
+++ b/src/Runtime/Runtime/System.Windows.Data/PropertyPathNode.cs
@@ -41,7 +41,8 @@ namespace Windows.UI.Xaml.Data
         internal void UpdateValueAndIsBroken(object newValue, bool isBroken)
         {
             bool emitBrokenChanged = IsBroken != isBroken;
-            bool emitValueChanged = Value != newValue;
+            bool emitValueChanged = Value != newValue // reference equals works well for immutable types, like strings for example 
+                || Value is System.Collections.ICollection;//Partial workaround: If the Value is a collection, then we cannot asume that the collection has not been changed only by doing a reference equals.
 
             IsBroken = isBroken;
             Value = newValue;


### PR DESCRIPTION
- Emit "ValueChanged" on listeners also for properties of collection types even if the "Old Value" reference equals the "New Value".