### PR TITLE
[os-container-build] Do not show dialog in container

### DIFF
--- a/src/Compiler/Compiler.TypeScriptDefToCSharp/Program.cs
+++ b/src/Compiler/Compiler.TypeScriptDefToCSharp/Program.cs
@@ -110,13 +110,17 @@ namespace TypeScriptDefToCSharp
 
                     Logger.WriteMessage("Parsing file: " + fileName);
 
-                    // Display the Progress Dialog (on UI thread):
                     typeScriptFileNameToProgress[fileName] = "Processing " + fileName;
-                    ProgressDialog.ShowOnUIThread(fileName, typeScriptFileNameToProgress);
                     Action<string> methodToUpdateProgress = (text =>
-                        {
-                            typeScriptFileNameToProgress[fileName] = "processing token '" + (text ?? "") + "' in file '" + fileName + "'";
-                        });
+                    {
+                        typeScriptFileNameToProgress[fileName] = "processing token '" + (text ?? "") + "' in file '" + fileName + "'";
+                    });
+
+                    // Display the Progress Dialog (on UI thread):
+                    if (Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER") == null)
+                    {
+                        ProgressDialog.ShowOnUIThread(fileName, typeScriptFileNameToProgress);
+                    }
 
                     // Add this file to the New Infos
                     DTSNew.TypeScriptDefinitionFiles.Add(new TypeScriptDefinitionFile()


### PR DESCRIPTION
msbuild crashes dramatically with an error only in the event viewer of a container due to lack of graphical interface in the container